### PR TITLE
[feat] 6 add error handling facilities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,8 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:1.9.0")
+    implementation(platform("io.arrow-kt:arrow-stack:2.1.0"))
+    implementation("io.arrow-kt:arrow-core")
     implementation("org.slf4j:slf4j-api:2.0.17")
     implementation(platform("org.apache.logging.log4j:log4j-bom:2.25.2"))
     implementation("org.apache.logging.log4j:log4j-api")

--- a/src/main/kotlin/error/ConfigError.kt
+++ b/src/main/kotlin/error/ConfigError.kt
@@ -1,0 +1,32 @@
+package com.an5on.error
+
+sealed interface ConfigError : PunktError {
+    override val code: String
+
+    data class InvalidHomeDir(
+        val path: String?,
+        override val cause: Throwable? = null
+    ) : ConfigError {
+        override val code: String = "CONFIG_INVALID_HOME_DIR"
+        override val message: String
+            get() = "Invalid or missing home directory: ${path ?: "<null>"}"
+    }
+
+    data class InvalidLocalDir(
+        val path: String,
+        override val cause: Throwable? = null
+    ) : ConfigError {
+        override val code: String = "CONFIG_INVALID_LOCAL_DIR"
+        override val message: String
+            get() = "Invalid local data directory: $path"
+    }
+
+    data class SerializationFailed(
+        val reason: String,
+        override val cause: Throwable? = null
+    ) : ConfigError {
+        override val code: String = "CONFIG_SERIALIZATION_FAILED"
+        override val message: String
+            get() = "Failed to serialize/deserialize configuration: $reason"
+    }
+}

--- a/src/main/kotlin/error/CredentialError.kt
+++ b/src/main/kotlin/error/CredentialError.kt
@@ -1,0 +1,33 @@
+package com.an5on.error
+
+/** Errors related to retrieving or using credentials. */
+sealed interface CredentialError : PunktError {
+    override val code: String
+
+    data class ManagerNotFound(
+        val command: String = "git-credential-manager",
+        override val cause: Throwable? = null
+    ) : CredentialError {
+        override val code: String = "CRED_MANAGER_NOT_FOUND"
+        override val message: String
+            get() = "Credential manager not found or not executable: $command"
+    }
+
+    data class NotConfigured(
+        val host: String,
+        override val cause: Throwable? = null
+    ) : CredentialError {
+        override val code: String = "CRED_NOT_CONFIGURED"
+        override val message: String
+            get() = "No credentials configured for host: $host"
+    }
+
+    data class Invalid(
+        val reason: String,
+        override val cause: Throwable? = null
+    ) : CredentialError {
+        override val code: String = "CRED_INVALID"
+        override val message: String
+            get() = "Invalid credentials: $reason"
+    }
+}

--- a/src/main/kotlin/error/FilesystemError.kt
+++ b/src/main/kotlin/error/FilesystemError.kt
@@ -1,0 +1,53 @@
+package com.an5on.error
+
+/** Filesystem-related domain errors. */
+sealed interface FilesystemError : PunktError {
+    override val code: String
+
+    data class PathNotFound(
+        val path: String,
+        override val cause: Throwable? = null
+    ) : FilesystemError {
+        override val code: String = "FS_PATH_NOT_FOUND"
+        override val message: String
+            get() = "Path not found: $path"
+    }
+
+    data class NotADirectory(
+        val path: String,
+        override val cause: Throwable? = null
+    ) : FilesystemError {
+        override val code: String = "FS_NOT_A_DIRECTORY"
+        override val message: String
+            get() = "Not a directory: $path"
+    }
+
+    data class AlreadyExists(
+        val path: String,
+        override val cause: Throwable? = null
+    ) : FilesystemError {
+        override val code: String = "FS_ALREADY_EXISTS"
+        override val message: String
+            get() = "Already exists: $path"
+    }
+
+    data class PermissionDenied(
+        val path: String,
+        val operation: String,
+        override val cause: Throwable? = null
+    ) : FilesystemError {
+        override val code: String = "FS_PERMISSION_DENIED"
+        override val message: String
+            get() = "Permission denied for $operation: $path"
+    }
+
+    data class IoFailure(
+        val path: String,
+        val operation: String,
+        override val cause: Throwable? = null
+    ) : FilesystemError {
+        override val code: String = "FS_IO_FAILURE"
+        override val message: String
+            get() = "I/O failure during $operation: $path"
+    }
+}

--- a/src/main/kotlin/error/GitError.kt
+++ b/src/main/kotlin/error/GitError.kt
@@ -1,0 +1,88 @@
+package com.an5on.error
+
+/** Git/JGit-related errors. */
+sealed interface GitError : PunktError {
+    override val code: String
+
+    data class InitFailed(
+        val directory: String,
+        override val cause: Throwable? = null
+    ) : GitError {
+        override val code: String = "GIT_INIT_FAILED"
+        override val message: String
+            get() = "Failed to initialise Git repository at $directory"
+    }
+
+    data class CloneFailed(
+        val uri: String,
+        val targetDir: String,
+        override val cause: Throwable? = null
+    ) : GitError {
+        override val code: String = "GIT_CLONE_FAILED"
+        override val message: String
+            get() = "Failed to clone $uri to $targetDir"
+    }
+
+    data class RepoNotFound(
+        val uri: String,
+        override val cause: Throwable? = null
+    ) : GitError {
+        override val code: String = "GIT_REPO_NOT_FOUND"
+        override val message: String
+            get() = "Remote repository not found: $uri"
+    }
+
+    data class InvalidRef(
+        val ref: String,
+        override val cause: Throwable? = null
+    ) : GitError {
+        override val code: String = "GIT_INVALID_REF"
+        override val message: String
+            get() = "Invalid Git reference/branch: $ref"
+    }
+
+    data class Transport(
+        val uri: String,
+        override val cause: Throwable
+    ) : GitError {
+        override val code: String = "GIT_TRANSPORT_ERROR"
+        override val message: String
+            get() = "Git transport error while accessing $uri: ${cause.message ?: cause::class.simpleName}"
+    }
+
+    data class AuthRequired(
+        val uri: String
+    ) : GitError {
+        override val code: String = "GIT_AUTH_REQUIRED"
+        override val message: String
+            get() = "Authentication required for $uri"
+        override val cause: Throwable? = null
+    }
+
+    data class AuthFailed(
+        val uri: String,
+        override val cause: Throwable? = null
+    ) : GitError {
+        override val code: String = "GIT_AUTH_FAILED"
+        override val message: String
+            get() = "Authentication failed for $uri"
+    }
+
+    data class SshHostKeyUnknown(
+        val host: String,
+        override val cause: Throwable? = null
+    ) : GitError {
+        override val code: String = "GIT_SSH_HOSTKEY_UNKNOWN"
+        override val message: String
+            get() = "Unknown SSH host key for $host"
+    }
+
+    data class SshIdentityNotFound(
+        val identityPath: String,
+        override val cause: Throwable? = null
+    ) : GitError {
+        override val code: String = "GIT_SSH_IDENTITY_NOT_FOUND"
+        override val message: String
+            get() = "SSH identity not found: $identityPath"
+    }
+}

--- a/src/main/kotlin/error/ProcessError.kt
+++ b/src/main/kotlin/error/ProcessError.kt
@@ -1,0 +1,50 @@
+package com.an5on.error
+
+/** Errors for starting and interacting with external processes. */
+sealed interface ProcessError : PunktError {
+    override val code: String
+
+    data class StartFailed(
+        val command: String,
+        val args: List<String> = emptyList(),
+        override val cause: Throwable
+    ) : ProcessError {
+        override val code: String = "PROC_START_FAILED"
+        override val message: String
+            get() = "Failed to start process: $command ${args.joinToString(" ")}".trim()
+    }
+
+    data class NonZeroExit(
+        val command: String,
+        val exitCode: Int,
+        val stderr: String? = null
+    ) : ProcessError {
+        override val code: String = "PROC_NON_ZERO_EXIT"
+        override val message: String
+            get() = buildString {
+                append("Process exited with code $exitCode: $command")
+                if (!stderr.isNullOrBlank()) append(" | stderr: ").append(stderr)
+            }
+        override val cause: Throwable? = null
+    }
+
+    data class TimedOut(
+        val command: String,
+        val timeoutMs: Long
+    ) : ProcessError {
+        override val code: String = "PROC_TIMEOUT"
+        override val message: String
+            get() = "Process timed out after ${timeoutMs}ms: $command"
+        override val cause: Throwable? = null
+    }
+
+    data class OutputParseFailed(
+        val command: String,
+        val reason: String,
+        override val cause: Throwable? = null
+    ) : ProcessError {
+        override val code: String = "PROC_OUTPUT_PARSE_FAILED"
+        override val message: String
+            get() = "Failed to parse process output for '$command': $reason"
+    }
+}

--- a/src/main/kotlin/error/PunktError.kt
+++ b/src/main/kotlin/error/PunktError.kt
@@ -1,0 +1,16 @@
+package com.an5on.error
+
+/**
+ * Root marker and contract for all domain errors in Punkt.
+ *
+ * Each error provides a stable [code], a human-friendly [message],
+ * and an optional underlying [cause].
+ */
+interface PunktError {
+    val code: String
+    val message: String
+    val cause: Throwable?
+        get() = null
+    val statusCode: Int
+        get() = 1
+}

--- a/src/main/kotlin/error/UnexpectedError.kt
+++ b/src/main/kotlin/error/UnexpectedError.kt
@@ -1,0 +1,10 @@
+package com.an5on.error
+
+/** A generic, unexpected domain error wrapper to capture unknown failures. */
+data class UnexpectedError(
+    override val message: String,
+    override val cause: Throwable? = null,
+    val context: Map<String, String> = emptyMap()
+) : PunktError {
+    override val code: String = "UNEXPECTED"
+}


### PR DESCRIPTION
This pull request introduces a comprehensive, type-safe error hierarchy for the codebase by defining a set of domain-specific error types as sealed interfaces and data classes in the `com.an5on.error` package. The new structure provides clear, descriptive, and consistent error reporting across configuration, credentials, filesystem, Git operations, process management, and unexpected failures.

The most important changes are:

**Error System Foundation**
* Introduced the `PunktError` interface as the root contract for all domain errors, specifying standard properties like `code`, `message`, `cause`, and `statusCode`.
* Added a generic `UnexpectedError` data class to capture and wrap unknown or unexpected failures, supporting custom context information.

**Domain-Specific Error Types**
* Added `ConfigError`, a sealed interface with data classes for configuration-related errors such as invalid home/local directories and serialization failures.
* Added `CredentialError`, a sealed interface with data classes for credential management errors, including missing managers, not configured hosts, and invalid credentials.
* Added `FilesystemError`, a sealed interface with data classes for filesystem issues like path not found, not a directory, already exists, permission denied, and I/O failures.
* Added `GitError`, a sealed interface with data classes for various Git-related errors, such as initialization/clone failures, repo not found, invalid refs, transport/authentication/SSH errors.
* Added `ProcessError`, a sealed interface with data classes for process-related issues, including start failures, non-zero exit codes, timeouts, and output parsing failures.