### PR TITLE
[feat] add command activate

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,5 +1,6 @@
 package com.an5on
 
+import com.an5on.command.Activate
 import com.an5on.command.Command
 import com.an5on.command.Init
 import com.an5on.command.Sync
@@ -26,6 +27,7 @@ fun main(args: Array<String>) {
 
     Command().subcommands(
         Init(),
-        Sync()
+        Sync(),
+        Activate()
     ).main(args)
 }

--- a/src/main/kotlin/command/Activate.kt
+++ b/src/main/kotlin/command/Activate.kt
@@ -1,0 +1,73 @@
+package com.an5on.command
+
+import com.an5on.operation.ActivateOptions
+import com.an5on.operation.Operations.activate
+import com.an5on.operation.Operations.activateExistingLocal
+import com.an5on.utils.Echos
+import com.an5on.utils.FileUtils.replaceTildeWithAbsPathname
+import com.an5on.utils.echoStage
+import com.an5on.utils.echoSuccess
+import com.an5on.utils.echoWarning
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.convert
+import com.github.ajalt.clikt.parameters.arguments.multiple
+import com.github.ajalt.clikt.parameters.arguments.optional
+import com.github.ajalt.clikt.parameters.arguments.unique
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.path
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.system.exitProcess
+
+class Activate: CliktCommand() {
+    val recursive by option("-r", "--recursive", help="Sync directories recursively").flag(default = true)
+    val include by option("-i", "--include", help="Include files matching the regex pattern")
+    val exclude by option("-x", "--exclude", help="Exclude files matching the regex pattern")
+    val targets by argument().convert {
+        replaceTildeWithAbsPathname(it)
+    }.path(
+        canBeFile = true,
+        canBeDir = true,
+        canBeSymlink = true
+    ).multiple().unique().optional()
+
+    override fun run() {
+        val options = ActivateOptions(
+            recursive,
+            include?.toRegex() ?: Regex(".*"), // Matches everything if include is null
+            exclude?.toRegex() ?: Regex("$^") // Matches nothing if exclude is null
+        )
+
+        if (targets == null) {
+            echoStage("Activating all dotfiles in Punkt local repository")
+            activateExistingLocal(ActivateOptions(true, Regex(".*"), Regex("$^")),
+                Echos(::echo, ::echoStage, ::echoSuccess, ::echoWarning)
+            ).fold(
+                ifLeft = { e ->
+                    echo(e.message, err = true)
+                    logger.error { "${e.message}\n${e.cause?.stackTraceToString()}"}
+                    exitProcess(e.statusCode)
+                },
+                ifRight = {
+                    echoSuccess()
+                }
+            )
+        } else {
+            activate(targets!!, options, Echos(::echo, ::echoStage, ::echoSuccess, ::echoWarning)).fold(
+                ifLeft = { e ->
+                    echo(e.message, err = true)
+                    logger.error { "${e.message}\n${e.cause?.stackTraceToString()}"}
+                    exitProcess(e.statusCode)
+                },
+                ifRight = {
+                    echoSuccess()
+                }
+            )
+        }
+    }
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+}

--- a/src/main/kotlin/operation/ActivateOptions.kt
+++ b/src/main/kotlin/operation/ActivateOptions.kt
@@ -1,0 +1,7 @@
+package com.an5on.operation
+
+data class ActivateOptions(
+    val recursive: Boolean,
+    val include: Regex,
+    val exclude: Regex
+)

--- a/src/main/kotlin/states/active/ActiveState.kt
+++ b/src/main/kotlin/states/active/ActiveState.kt
@@ -1,0 +1,86 @@
+package com.an5on.states.active
+
+import arrow.core.Either
+import arrow.core.raise.either
+import arrow.core.raise.ensure
+import com.an5on.config.ActiveConfiguration
+import com.an5on.config.ActiveConfiguration.homeDirAbsPath
+import com.an5on.config.ActiveConfiguration.localDirAbsPath
+import com.an5on.error.FileError
+import com.an5on.error.LocalError
+import com.an5on.error.PunktError
+import org.apache.commons.io.FileUtils
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.Path
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+import kotlin.io.path.pathString
+import kotlin.io.path.relativeTo
+
+object ActiveState {
+    val dotReplacementStringRegex = Regex(ActiveConfiguration.dotReplacementString)
+
+    fun Path.toActivePath(): Either<LocalError, Path> = either {
+        if (!this@toActivePath.isAbsolute) {
+            homeDirAbsPath.resolve(
+                this@toActivePath.pathString.replace(dotReplacementStringRegex, ".")
+            ).normalize()
+        } else if (this@toActivePath.startsWith(localDirAbsPath)) {
+            homeDirAbsPath.resolve(
+                this@toActivePath.relativeTo(localDirAbsPath).pathString
+                    .replace(dotReplacementStringRegex, ".")
+            )
+        } else {
+            Path(
+                this@toActivePath.pathString.replace(dotReplacementStringRegex, ".")
+            ).normalize()
+        }
+    }
+
+    fun Path.existsInActive(): Either<PunktError, Boolean> = either {
+        this@existsInActive.toActivePath().bind().exists()
+    }
+
+    fun Path.contentEqualsActive(): Either<PunktError, Boolean> = either {
+        ensure(this@contentEqualsActive.exists()) {
+            FileError.PathNotFound(this@contentEqualsActive)
+        }
+
+        val localFile = this@contentEqualsActive.toFile()
+
+        val activeFile = this@contentEqualsActive.toActivePath().bind().toFile()
+        ensure(activeFile.exists()) {
+            LocalError.LocalPathNotFound(this@contentEqualsActive)
+        }
+
+        FileUtils.contentEquals(activeFile, localFile)
+    }
+
+    fun copyFromLocalToActive(localPath: Path): Either<PunktError, Unit> = either {
+        ensure(localPath.exists()) {
+            LocalError.LocalPathNotFound(localPath)
+        }
+
+        val localAbsPath = if (localPath.isAbsolute) {
+            localPath
+        } else {
+            localDirAbsPath.resolve(localPath).normalize()
+        }
+
+        val activePath = localAbsPath.toActivePath().bind()
+        makeDirs(localAbsPath)
+
+        Files.copy(localAbsPath, activePath, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+    }
+
+    fun makeDirs(localPath: Path): Either<PunktError, Unit> = either {
+        val activePath = localPath.toActivePath().bind()
+
+        if (activePath.isDirectory() && !activePath.exists()) {
+            Files.createDirectories(activePath)
+        } else if (!activePath.parent.exists()) {
+            Files.createDirectories(activePath.parent)
+        }
+    }
+}

--- a/src/main/kotlin/states/active/ActiveTransaction.kt
+++ b/src/main/kotlin/states/active/ActiveTransaction.kt
@@ -1,0 +1,24 @@
+package com.an5on.states.active
+
+import arrow.core.Either
+import com.an5on.error.PunktError
+import java.nio.file.Path
+
+abstract class ActiveTransaction {
+    abstract val type: ActiveTransactionType
+    abstract val localPath: Path
+
+    abstract fun run(): Either<PunktError, Unit>
+
+    override fun equals(other: Any?): Boolean = if (other is ActiveTransaction) {
+        this.type == other.type && this.localPath == other.localPath
+    } else {
+        false
+    }
+
+    override fun hashCode(): Int {
+        var result = type.hashCode()
+        result = 31 * result + localPath.hashCode()
+        return result
+    }
+}

--- a/src/main/kotlin/states/active/ActiveTransactionCopyToActive.kt
+++ b/src/main/kotlin/states/active/ActiveTransactionCopyToActive.kt
@@ -1,0 +1,17 @@
+package com.an5on.states.active
+
+import arrow.core.Either
+import arrow.core.raise.either
+import com.an5on.error.PunktError
+import com.an5on.states.active.ActiveState.copyFromLocalToActive
+import java.nio.file.Path
+
+class ActiveTransactionCopyToActive(
+    override val localPath: Path,
+) : ActiveTransaction() {
+    override val type = ActiveTransactionType.COPY_TO_ACTIVE
+
+    override fun run(): Either<PunktError, Unit> = either {
+        copyFromLocalToActive(localPath).bind()
+    }
+}

--- a/src/main/kotlin/states/active/ActiveTransactionMakeDirectories.kt
+++ b/src/main/kotlin/states/active/ActiveTransactionMakeDirectories.kt
@@ -1,0 +1,17 @@
+package com.an5on.states.active
+
+import com.an5on.error.PunktError
+import arrow.core.Either
+import arrow.core.raise.either
+import com.an5on.states.active.ActiveState.makeDirs
+import java.nio.file.Path
+
+class ActiveTransactionMakeDirectories(
+    override val localPath: Path
+): ActiveTransaction() {
+    override val type = ActiveTransactionType.MKDIRS
+
+    override fun run(): Either<PunktError, Unit> = either {
+        makeDirs(localPath).bind()
+    }
+}

--- a/src/main/kotlin/states/active/ActiveTransactionType.kt
+++ b/src/main/kotlin/states/active/ActiveTransactionType.kt
@@ -1,0 +1,6 @@
+package com.an5on.states.active
+
+enum class ActiveTransactionType {
+    COPY_TO_ACTIVE,
+    MKDIRS,
+}


### PR DESCRIPTION
This pull request introduces a new "activate" feature to the application, allowing users to activate dotfiles from the local repository into their home directory. The implementation includes a new command, supporting options for recursion and file filtering, and a set of supporting classes and logic for handling activation transactions. The changes are grouped into the following themes:

**New Command and CLI Integration**

* Added the `Activate` command to the CLI, including options for recursion, inclusion/exclusion patterns, and target paths. This enables users to activate dotfiles from the local repository to their home directory via the command line. [[1]](diffhunk://#diff-c94d42ff55d131436b96cfe54bf79df0fbb2d7b13c7dab6afe631f23e4f4e687R1-R73) [[2]](diffhunk://#diff-2e9c104fc5144b79e630c4b1f599551d1b2f72462926691c2973b8e1d9da0b35R3) [[3]](diffhunk://#diff-2e9c104fc5144b79e630c4b1f599551d1b2f72462926691c2973b8e1d9da0b35L29-R31)

**Activation Logic and Options**

* Introduced the `ActivateOptions` data class to encapsulate activation parameters such as recursion and file filtering.
* Implemented `activate` and `activateExistingLocal` functions in `Operations`, which handle the logic for activating specified files or all files, including file filtering and recursive directory handling. [[1]](diffhunk://#diff-73669475766eccdda422d439bfc5456fed07ee777a3d820077f34dc030e4be36L34-R44) [[2]](diffhunk://#diff-73669475766eccdda422d439bfc5456fed07ee777a3d820077f34dc030e4be36L108-R200)

**Active State and Transaction System**

* Added the `ActiveState` object for path conversions, existence checks, file comparisons, and file operations between local and active directories.
* Created a transaction system with `ActiveTransaction`, `ActiveTransactionCopyToActive`, and `ActiveTransactionMakeDirectories` classes, representing atomic activation operations. [[1]](diffhunk://#diff-aa19713ae8ee42ae652a79aa3e237e7a3fb76af5e35bf29c3393ffb8c4ee26b0R1-R24) [[2]](diffhunk://#diff-9d387d9043dc33132b9626bc243937e648c1fcd0c81f910251d4008e41369112R1-R17) [[3]](diffhunk://#diff-9ad39f3909cdbb86661bd1eab99b0c359c14ac22905939a7c74effd0343f8c19R1-R17) [[4]](diffhunk://#diff-9d4d0dae557ba311082d174476b35ba73bb534b89a626c0c478cee19b2a6c8d3R1-R6)

**Internal Refactoring**

* Updated imports and internal references to support the new activation feature and transaction system.