### PR TITLE
[feat] add command list

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -3,6 +3,7 @@ package com.an5on
 import com.an5on.command.Activate
 import com.an5on.command.Command
 import com.an5on.command.Init
+import com.an5on.command.List
 import com.an5on.command.Sync
 import com.an5on.config.Configuration
 import com.github.ajalt.clikt.core.main
@@ -28,6 +29,7 @@ fun main(args: Array<String>) {
     Command().subcommands(
         Init(),
         Sync(),
-        Activate()
+        Activate(),
+        List()
     ).main(args)
 }

--- a/src/main/kotlin/command/List.kt
+++ b/src/main/kotlin/command/List.kt
@@ -1,0 +1,56 @@
+package com.an5on.command
+
+import com.an5on.operation.ListOptions
+import com.an5on.operation.Operations.list
+import com.an5on.operation.Operations.listExistingLocal
+import com.an5on.operation.PathStyles
+import com.an5on.utils.Echos
+import com.an5on.utils.FileUtils.replaceTildeWithAbsPathname
+import com.an5on.utils.echoStage
+import com.an5on.utils.echoSuccess
+import com.an5on.utils.echoWarning
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.convert
+import com.github.ajalt.clikt.parameters.arguments.multiple
+import com.github.ajalt.clikt.parameters.arguments.optional
+import com.github.ajalt.clikt.parameters.arguments.unique
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.choice
+import com.github.ajalt.clikt.parameters.types.path
+
+class List: CliktCommand() {
+    val include by option("-i", "--include", help="Include paths matching the regex pattern")
+    val exclude by option("-x", "--exclude", help="Exclude paths matching the regex pattern")
+    val pathStyle by option(
+       "-p", "--path-style",
+        help = "Set the path style for displaying the list of managed dotfiles. Options are 'absolute' or 'relative' to the home directory."
+    ).choice(
+        *PathStyles.entries
+            .map{ it.name.lowercase().replace("_", "-") }
+            .toTypedArray(),
+    ).default("absolute")
+    val paths by argument().convert {
+        replaceTildeWithAbsPathname(it)
+    }.path(
+        canBeFile = true,
+        canBeDir = true,
+        canBeSymlink = true
+    ).multiple().unique().optional()
+
+
+    override fun run() {
+        val options = ListOptions(
+            include?.toRegex() ?: Regex(".*"), // Matches everything if include is null
+            exclude?.toRegex() ?: Regex("$^"), // Matches nothing if exclude is null
+            PathStyles.valueOf(pathStyle.uppercase().replace("-", "_")),
+        )
+
+        if (paths == null) {
+            listExistingLocal(options, Echos(::echo, ::echoStage, ::echoSuccess, ::echoWarning))
+        } else {
+            list(paths!!, options, Echos(::echo, ::echoStage, ::echoSuccess, ::echoWarning))
+        }
+    }
+}

--- a/src/main/kotlin/operation/ListOptions.kt
+++ b/src/main/kotlin/operation/ListOptions.kt
@@ -1,0 +1,7 @@
+package com.an5on.operation
+
+class ListOptions (
+    val include: Regex,
+    val exclude: Regex,
+    val pathStyle: PathStyles
+)

--- a/src/main/kotlin/operation/Operations.kt
+++ b/src/main/kotlin/operation/Operations.kt
@@ -4,20 +4,20 @@ import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import com.an5on.config.ActiveConfiguration
+import com.an5on.config.ActiveConfiguration.homeDirAbsPath
+import com.an5on.config.ActiveConfiguration.localDirAbsPath
 import com.an5on.error.LocalError
 import com.an5on.error.PunktError
 import com.an5on.states.active.ActiveState
 import com.an5on.states.active.ActiveState.contentEqualsActive
 import com.an5on.states.active.ActiveState.existsInActive
 import com.an5on.states.active.ActiveState.toActivePath
-import com.an5on.states.active.ActiveTransaction
 import com.an5on.states.active.ActiveTransactionCopyToActive
 import com.an5on.states.active.ActiveTransactionMakeDirectories
 import com.an5on.states.local.LocalState
 import com.an5on.states.local.LocalState.contentEqualsLocal
 import com.an5on.states.local.LocalState.existsInLocal
 import com.an5on.states.local.LocalState.toLocalPath
-import com.an5on.states.local.LocalTransaction
 import com.an5on.states.local.LocalTransactionCopyToLocal
 import com.an5on.states.local.LocalTransactionMakeDirectories
 import com.an5on.states.tracked.TrackedEntriesStore
@@ -25,6 +25,10 @@ import com.an5on.states.tracked.TrackedEntryDir
 import com.an5on.states.tracked.TrackedEntryFile
 import com.an5on.utils.Echos
 import com.an5on.utils.FileUtils.getBlake3HashHexString
+import org.apache.commons.io.FileUtils
+import org.apache.commons.io.filefilter.FileFilterUtils
+import org.apache.commons.io.filefilter.RegexFileFilter
+import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.BasicFileAttributes
@@ -66,7 +70,7 @@ object Operations {
             acc
         }
 
-        if (accumulatedActivePaths.any { it.startsWith(ActiveConfiguration.localDirAbsPath) }) {
+        if (accumulatedActivePaths.any { it.startsWith(localDirAbsPath) }) {
             echo.echoWarning(
                 "Directories and files in the local Punkt directory (${ActiveConfiguration.localDirAbsPathname}) will not be synced."
             )
@@ -76,7 +80,7 @@ object Operations {
                     .toMutableSet()
         }
 
-        LocalState.pendingTransactions.addAll(accumulatedActivePaths.fold(mutableSetOf<LocalTransaction>()) { acc, activePath ->
+        LocalState.pendingTransactions.addAll(accumulatedActivePaths.fold(mutableSetOf()) { acc, activePath ->
             if (activePath.existsInLocal().bind()) {
                 if (!activePath.isDirectory() && !activePath.contentEqualsLocal().bind()) {
                     acc.add(LocalTransactionCopyToLocal(activePath))
@@ -101,9 +105,9 @@ object Operations {
     }
 
     fun syncExistingLocal(options: SyncOptions, echo: Echos): Either<PunktError, Unit> = either {
-        val activePathsInLocal = ActiveConfiguration.localDirAbsPath
+        val activePathsInLocal = localDirAbsPath
             .walk(PathWalkOption.BREADTH_FIRST)
-            .filter { it != ActiveConfiguration.localDirAbsPath }
+            .filter { it != localDirAbsPath }
             .map { it.toActivePath().bind() }
             .filter { it.exists() }
             .toSet()
@@ -152,7 +156,7 @@ object Operations {
             acc
         }
 
-        ActiveState.pendingTransactions.addAll(accumulatedLocalPaths.fold(mutableSetOf<ActiveTransaction>()) { acc, localPath ->
+        ActiveState.pendingTransactions.addAll(accumulatedLocalPaths.fold(mutableSetOf()) { acc, localPath ->
             if (localPath.existsInActive().bind()) {
                 if (!localPath.isDirectory() && !localPath.contentEqualsActive().bind()) {
                     acc.add(ActiveTransactionCopyToActive(localPath))
@@ -175,13 +179,13 @@ object Operations {
             LocalError.LocalNotFound()
         }
 
-        val localPathsInLocal = ActiveConfiguration.localDirAbsPath
+        val localPathsInLocal = localDirAbsPath
             .walk(PathWalkOption.BREADTH_FIRST)
-            .filter { it != ActiveConfiguration.localDirAbsPath }
+            .filter { it != localDirAbsPath }
 
 
         ActiveState.pendingTransactions.addAll(
-            localPathsInLocal.fold(mutableSetOf<ActiveTransaction>()) { acc, localPath ->
+            localPathsInLocal.fold(mutableSetOf()) { acc, localPath ->
                 if (localPath.existsInActive().bind()) {
                     if (!localPath.isDirectory() && !localPath.contentEqualsActive().bind()) {
                         acc.add(ActiveTransactionCopyToActive(localPath))
@@ -196,5 +200,89 @@ object Operations {
             })
 
         ActiveState.transact().bind()
+    }
+
+    fun list(activePaths: Set<Path>, options: ListOptions, echo: Echos): Either<PunktError, Unit> = either {
+
+        ensure(LocalState.exists()) {
+            LocalError.LocalNotFound()
+        }
+
+        activePaths.forEach {
+            ensure(it.existsInLocal().bind()) {
+                LocalError.LocalPathNotFound(it)
+            }
+        }
+
+        val includeExcludeFilter = RegexFileFilter(options.include.pattern)
+            .and(RegexFileFilter(options.exclude.pattern).negate())
+            .and(FileFilterUtils.makeCVSAware(null))
+
+        val localPaths = activePaths.map { it.toLocalPath().bind() }.toSet()
+        val accumulatedLocalFiles = localPaths.fold(mutableSetOf<File>()) { acc, localPath ->
+            acc.addAll(FileUtils.listFilesAndDirs(
+                localPath.toFile(),
+                includeExcludeFilter,
+                includeExcludeFilter,
+            ))
+            acc
+        }
+
+        printFiles(accumulatedLocalFiles, options.pathStyle, echo).bind()
+    }
+
+    fun listExistingLocal(options: ListOptions, echos: Echos): Either<PunktError, Unit> = either {
+
+        ensure(LocalState.exists()) {
+            LocalError.LocalNotFound()
+        }
+
+        val includeExcludeFilter = RegexFileFilter(options.include.pattern)
+            .and(RegexFileFilter(options.exclude.pattern).negate())
+            .and(FileFilterUtils.makeCVSAware(null))
+
+        val localFiles = FileUtils.listFilesAndDirs(
+            localDirAbsPath.toFile(),
+            includeExcludeFilter,
+            includeExcludeFilter,
+        )
+
+        printFiles(localFiles, options.pathStyle, echos).bind()
+    }
+
+    private fun printFiles(files: Collection<File>, pathStyle: PathStyles, echos: Echos): Either<PunktError, Unit> = either {
+        when (pathStyle) {
+            PathStyles.ABSOLUTE -> {
+                echos.echo(
+                    files
+                        .map { it.toPath().toActivePath().bind() }
+                        .sorted()
+                        .joinToString("\n"), true, false)
+            }
+
+            PathStyles.RELATIVE -> {
+                echos.echo(
+                    files
+                        .map { it.toPath().toActivePath().bind().relativeTo(homeDirAbsPath) }
+                        .sorted()
+                        .joinToString("\n"), true, false)
+            }
+
+            PathStyles.LOCAL_ABSOLUTE -> {
+                echos.echo(
+                    files
+                        .sorted()
+                        .joinToString("\n"), true, false
+                )
+            }
+
+            PathStyles.LOCAL_RELATIVE -> {
+                echos.echo(
+                    files
+                        .map { it.toPath().relativeTo(localDirAbsPath) }
+                        .sorted()
+                        .joinToString("\n"), true, false)
+            }
+        }
     }
 }

--- a/src/main/kotlin/operation/PathStyles.kt
+++ b/src/main/kotlin/operation/PathStyles.kt
@@ -1,0 +1,8 @@
+package com.an5on.operation
+
+enum class PathStyles {
+    ABSOLUTE,
+    RELATIVE,
+    LOCAL_ABSOLUTE,
+    LOCAL_RELATIVE
+}


### PR DESCRIPTION
This pull request adds a new `list` command to the application, allowing users to display managed dotfiles with flexible filtering and path formatting options. The implementation introduces supporting options and utilities for filtering and formatting, and refactors some internal references for clarity and consistency.

**New list command and options:**

* Added a new `List` subcommand (`List.kt`) to the CLI, which lists dotfiles with options for filtering by regex and formatting path styles. The command supports arguments for inclusion/exclusion patterns and path style selection.
* Introduced the `ListOptions` data class to encapsulate filtering and formatting options for the list operation.
* Added the `PathStyles` enum to support different ways of displaying file paths (absolute, relative, local absolute, local relative).

**Listing logic and utilities:**

* Implemented `list` and `listExistingLocal` functions in `Operations.kt` to perform listing based on provided options, using regex filters and path style formatting. Added a helper `printFiles` function for output formatting.

**Internal refactoring for consistency:**

* Refactored references to `localDirAbsPath` and related variables to use direct imports and consistent naming throughout `Operations.kt`, improving code clarity and maintainability. [[1]](diffhunk://#diff-73669475766eccdda422d439bfc5456fed07ee777a3d820077f34dc030e4be36L69-R73) [[2]](diffhunk://#diff-73669475766eccdda422d439bfc5456fed07ee777a3d820077f34dc030e4be36L104-R110) [[3]](diffhunk://#diff-73669475766eccdda422d439bfc5456fed07ee777a3d820077f34dc030e4be36L178-R188)

**CLI integration:**

* Registered the new `List` command in the application's main entry point, making it available alongside existing commands. [[1]](diffhunk://#diff-2e9c104fc5144b79e630c4b1f599551d1b2f72462926691c2973b8e1d9da0b35R6) [[2]](diffhunk://#diff-2e9c104fc5144b79e630c4b1f599551d1b2f72462926691c2973b8e1d9da0b35L31-R33)