### PR TITLE
[test] add test for local state

### DIFF
--- a/src/test/kotlin/states/local/LocalUtilsTest.kt
+++ b/src/test/kotlin/states/local/LocalUtilsTest.kt
@@ -1,0 +1,238 @@
+package states.local
+
+import com.an5on.config.ActiveConfiguration.configuration
+import com.an5on.states.local.LocalUtils.isLocal
+import com.an5on.states.local.LocalUtils.toLocal
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.io.path.Path
+import kotlin.io.path.pathString
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class LocalUtilsTest {
+    @Test
+    fun pathToLocalWithPathInHomeForWin() {
+
+        val subject = configuration.global.activeStatePath.resolve(".test\\file.txt")
+        val result =
+            configuration.global.localStatePath.resolve(configuration.global.dotReplacementPrefix + "test\\file.txt")
+
+        assertEquals(subject.toLocal(), result)
+    }
+
+    @Test
+    fun pathToLocalWithRelativePathForWin() {
+
+        val subject = Path(".test\\file.txt")
+        val result =
+            configuration.global.localStatePath.resolve(configuration.global.dotReplacementPrefix + "test\\file.txt")
+
+        assertEquals(subject.toLocal(), result)
+    }
+
+    @Test
+    fun pathToLocalWithNotInHomePathForWin() {
+
+        val subject = Path("C:\\ProgramFiles\\.test\\file.txt")
+        val result = Path("C:\\ProgramFiles\\" + configuration.global.dotReplacementPrefix + "test\\file.txt")
+
+        assertEquals(subject.toLocal(), result)
+    }
+
+    @Test
+    fun pathToLocalWithLocalPathForWin() {
+
+        val subject = configuration.global.activeStatePath.resolve(".test\\file.txt").toLocal()
+
+        assertEquals(subject, subject)
+    }
+
+    @Test
+    fun fileToLocalWithPathInHomeForWin() {
+
+        val subject = File(configuration.global.activeStatePath.resolve(".test\\file.txt").pathString)
+        val result =
+            configuration.global.localStatePath.resolve(configuration.global.dotReplacementPrefix + "test\\file.txt").toFile()
+        assertEquals(subject.toLocal(), result)
+    }
+
+    @Test
+    fun fileToLocalWithNotInHomePathForWin() {
+
+        val subject = File(".test\\file.txt")
+        val result =
+            configuration.global.localStatePath.resolve(configuration.global.dotReplacementPrefix + "test\\file.txt").toFile()
+        assertEquals(subject.toLocal(), result)
+    }
+
+    @Test
+    fun fileToLocalWithPathNotInForWin() {
+
+        val subject = File("C:\\ProgramFiles\\.test\\file.txt")
+        val result =
+            Path("C:\\ProgramFiles\\" + configuration.global.dotReplacementPrefix + "test\\file.txt").toFile()
+        assertEquals(subject.toLocal(), result)
+    }
+
+    @Test
+    fun pathIsLocalWithPathInHomeForWin() {
+
+        val subject = configuration.global.activeStatePath.resolve(".test\\file.txt")
+
+        assertFalse(subject.isLocal())
+    }
+
+    @Test
+    fun pathIsLocalWithRelativePathForWin() {
+
+        val subject = Path(".test\\file.txt")
+
+        assertFalse(subject.isLocal())
+    }
+
+    @Test
+    fun pathIsLocalWithNotInHomePathForWin() {
+
+        val subject = Path("C:\\ProgramFiles\\.test\\file.txt")
+
+        assertFalse(subject.isLocal())
+    }
+
+    @Test
+    fun pathIsLocalWithLocalPathForWin() {
+
+        val subject = configuration.global.activeStatePath.resolve(".test\\file.txt").toLocal()
+
+        assertTrue(subject.isLocal())
+    }
+
+    @Test
+    fun fileIsLocalWithLocalPathForWin() {
+
+        val subject = configuration.global.activeStatePath.resolve(".test\\file.txt").toLocal().toFile()
+
+        assertTrue(subject.isLocal())
+    }
+
+    @Test
+    fun fileIsLocalWithNonLocalPathForWin() {
+
+        val subject = Path(".test\\file.txt").toFile()
+
+        assertFalse(subject.isLocal())
+    }
+
+    @Test
+    fun pathToLocalWithPathInHomeForUnix() {
+
+        val subject = configuration.global.activeStatePath.resolve(".test/file.txt")
+        val result =
+            configuration.global.localStatePath.resolve(configuration.global.dotReplacementPrefix + "test/file.txt")
+
+        assertEquals(subject.toLocal(), result)
+    }
+
+    @Test
+    fun pathToLocalWithLocalPathForUnix() {
+
+        val subject = configuration.global.activeStatePath.resolve(".test/file.txt").toLocal()
+
+        assertEquals(subject, subject)
+    }
+
+    @Test
+    fun pathToLocalWithRelativePathForUnix() {
+
+        val subject = Path(".test/file.txt")
+        val result =
+            configuration.global.localStatePath.resolve(configuration.global.dotReplacementPrefix + "test\\file.txt")
+
+        assertEquals(subject.toLocal(), result)
+    }
+
+    @Test
+    fun pathToLocalWithNotInHomePathForUnix() {
+
+        val subject = Path("/ProgramFiles/.test/file.txt")
+        val result = Path("/ProgramFiles/" + configuration.global.dotReplacementPrefix + "test/file.txt")
+
+        assertEquals(subject.toLocal(), result)
+    }
+
+    @Test
+    fun fileToLocalWithPathInHomeForUnix() {
+
+        val subject = File(configuration.global.activeStatePath.resolve(".test/file.txt").pathString)
+        val result =
+            configuration.global.localStatePath.resolve(configuration.global.dotReplacementPrefix + "test/file.txt").toFile()
+        assertEquals(subject.toLocal(), result)
+    }
+
+    @Test
+    fun fileToLocalWithNotInHomePathForUnix() {
+
+        val subject = File(".test/file.txt")
+        val result =
+            configuration.global.localStatePath.resolve(configuration.global.dotReplacementPrefix + "test/file.txt").toFile()
+        assertEquals(subject.toLocal(), result)
+    }
+
+    @Test
+    fun fileToLocalWithRelativePathForUnix() {
+
+        val subject = File("/ProgramFiles/.test/file.txt")
+        val result =
+            Path("/ProgramFiles/" + configuration.global.dotReplacementPrefix + "test/file.txt").toFile()
+        assertEquals(subject.toLocal(), result)
+    }
+
+    @Test
+    fun pathIsLocalWithPathInHomeForUnix() {
+
+        val subject = configuration.global.activeStatePath.resolve(".test/file.txt")
+
+        assertFalse(subject.isLocal())
+    }
+
+    @Test
+    fun pathIsLocalWithRelativePathForUnix() {
+
+        val subject = Path(".test/file.txt")
+
+        assertFalse(subject.isLocal())
+    }
+
+    @Test
+    fun pathIsLocalWithNotInHomePathForUnix() {
+
+        val subject = Path("/ProgramFiles/.test/file.txt")
+
+        assertFalse(subject.isLocal())
+    }
+
+    @Test
+    fun pathIsLocalWithLocalPathForUnix() {
+
+        val subject = configuration.global.activeStatePath.resolve(".test/file.txt").toLocal()
+
+        assertTrue(subject.isLocal())
+    }
+
+    @Test
+    fun fileIsLocalWithLocalPathForUnix() {
+
+        val subject = configuration.global.activeStatePath.resolve(".test/file.txt").toLocal().toFile()
+
+        assertTrue(subject.isLocal())
+    }
+
+    @Test
+    fun fileIsLocalWithNonLocalPathForUnix() {
+
+        val subject = Path(".test/file.txt").toFile()
+
+        assertFalse(subject.isLocal())
+    }
+}

--- a/src/test/kotlin/states/local/LocalUtilsTest.kt
+++ b/src/test/kotlin/states/local/LocalUtilsTest.kt
@@ -6,6 +6,8 @@ import com.an5on.file.FileUtils.isLocal
 import com.an5on.file.FileUtils.toLocal
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
 import java.io.File
 import kotlin.io.path.Path
 import kotlin.io.path.pathString
@@ -128,6 +130,7 @@ class LocalUtilsTest : BaseTestWithTestConfiguration() {
     }
 
     @Test
+    @EnabledOnOs(OS.LINUX, OS.MAC)
     fun pathToLocalWithNotInHomePathForUnix() {
 
         val subject = Path("/ProgramFiles/.test/file.txt")
@@ -157,6 +160,7 @@ class LocalUtilsTest : BaseTestWithTestConfiguration() {
     }
 
     @Test
+    @EnabledOnOs(OS.LINUX, OS.MAC)
     fun fileToLocalWithRelativePathForUnix() {
 
         val subject = File("/ProgramFiles/.test/file.txt")

--- a/src/test/kotlin/states/local/LocalUtilsTest.kt
+++ b/src/test/kotlin/states/local/LocalUtilsTest.kt
@@ -1,8 +1,9 @@
 package states.local
 
+import BaseTestWithTestConfiguration
 import com.an5on.config.ActiveConfiguration.configuration
-import com.an5on.states.local.LocalUtils.isLocal
-import com.an5on.states.local.LocalUtils.toLocal
+import com.an5on.file.FileUtils.isLocal
+import com.an5on.file.FileUtils.toLocal
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -11,7 +12,7 @@ import kotlin.io.path.pathString
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
-class LocalUtilsTest {
+class LocalUtilsTest : BaseTestWithTestConfiguration() {
     @Test
     fun pathToLocalWithPathInHomeForWin() {
 
@@ -33,15 +34,6 @@ class LocalUtilsTest {
     }
 
     @Test
-    fun pathToLocalWithNotInHomePathForWin() {
-
-        val subject = Path("C:\\ProgramFiles\\.test\\file.txt")
-        val result = Path("C:\\ProgramFiles\\" + configuration.global.dotReplacementPrefix + "test\\file.txt")
-
-        assertEquals(subject.toLocal(), result)
-    }
-
-    @Test
     fun pathToLocalWithLocalPathForWin() {
 
         val subject = configuration.global.activeStatePath.resolve(".test\\file.txt").toLocal()
@@ -54,7 +46,8 @@ class LocalUtilsTest {
 
         val subject = File(configuration.global.activeStatePath.resolve(".test\\file.txt").pathString)
         val result =
-            configuration.global.localStatePath.resolve(configuration.global.dotReplacementPrefix + "test\\file.txt").toFile()
+            configuration.global.localStatePath.resolve(configuration.global.dotReplacementPrefix + "test\\file.txt")
+                .toFile()
         assertEquals(subject.toLocal(), result)
     }
 
@@ -63,16 +56,8 @@ class LocalUtilsTest {
 
         val subject = File(".test\\file.txt")
         val result =
-            configuration.global.localStatePath.resolve(configuration.global.dotReplacementPrefix + "test\\file.txt").toFile()
-        assertEquals(subject.toLocal(), result)
-    }
-
-    @Test
-    fun fileToLocalWithPathNotInForWin() {
-
-        val subject = File("C:\\ProgramFiles\\.test\\file.txt")
-        val result =
-            Path("C:\\ProgramFiles\\" + configuration.global.dotReplacementPrefix + "test\\file.txt").toFile()
+            configuration.global.localStatePath.resolve(configuration.global.dotReplacementPrefix + "test\\file.txt")
+                .toFile()
         assertEquals(subject.toLocal(), result)
     }
 
@@ -143,16 +128,6 @@ class LocalUtilsTest {
     }
 
     @Test
-    fun pathToLocalWithRelativePathForUnix() {
-
-        val subject = Path(".test/file.txt")
-        val result =
-            configuration.global.localStatePath.resolve(configuration.global.dotReplacementPrefix + "test\\file.txt")
-
-        assertEquals(subject.toLocal(), result)
-    }
-
-    @Test
     fun pathToLocalWithNotInHomePathForUnix() {
 
         val subject = Path("/ProgramFiles/.test/file.txt")
@@ -166,7 +141,8 @@ class LocalUtilsTest {
 
         val subject = File(configuration.global.activeStatePath.resolve(".test/file.txt").pathString)
         val result =
-            configuration.global.localStatePath.resolve(configuration.global.dotReplacementPrefix + "test/file.txt").toFile()
+            configuration.global.localStatePath.resolve(configuration.global.dotReplacementPrefix + "test/file.txt")
+                .toFile()
         assertEquals(subject.toLocal(), result)
     }
 
@@ -175,7 +151,8 @@ class LocalUtilsTest {
 
         val subject = File(".test/file.txt")
         val result =
-            configuration.global.localStatePath.resolve(configuration.global.dotReplacementPrefix + "test/file.txt").toFile()
+            configuration.global.localStatePath.resolve(configuration.global.dotReplacementPrefix + "test/file.txt")
+                .toFile()
         assertEquals(subject.toLocal(), result)
     }
 


### PR DESCRIPTION
This pull request adds a comprehensive set of unit tests for the local file path utility functions, ensuring correct behavior across both Windows and Unix environments. The tests cover scenarios for converting paths and files to their local equivalents and checking if a given path or file is considered local.

Test coverage improvements:

* Added `LocalUtilsTest` class to test the `toLocal` and `isLocal` extension functions for both `Path` and `File` types, verifying correct handling for paths in the home directory, relative paths, and paths already in local format.
* Included separate test cases for Windows and Unix-like systems, using platform-specific annotations where appropriate to ensure cross-platform correctness.