### PR TITLE
[test] add tests for git

### DIFF
--- a/src/main/kotlin/git/AddOperation.kt
+++ b/src/main/kotlin/git/AddOperation.kt
@@ -44,9 +44,9 @@ class AddOperation(
      */
     override fun operateWithBundled(): Either<GitError, Unit> = catchOrThrow<GitAPIException, Unit> {
         val localRepository = Git.open(repositoryPath.toFile())
-
+        val pattern = relativeTargetPath.pathString.replace("\\", "/")
         localRepository.add()
-            .addFilepattern(".${relativeTargetPath.pathString}")
+            .addFilepattern(pattern)
             .call()
     }.mapLeft {
         GitError.BundledGitOperationFailed("Add", it)
@@ -58,7 +58,7 @@ class AddOperation(
      * @return An [Either] containing a [GitError] on failure or the process's exit code on success.
      */
     override fun operateWithSystem(): Either<GitError, Int> = either {
-        val args = listOf("add", ".${relativeTargetPath.pathString}")
+        val args = listOf("add", relativeTargetPath.pathString)
 
         executeSystemGit(args, repositoryPath).bind()
     }

--- a/src/main/kotlin/git/AddOperation.kt
+++ b/src/main/kotlin/git/AddOperation.kt
@@ -36,6 +36,7 @@ class AddOperation(
     determineUseBundledGit(useBundledGitOption)
 ) {
     private val relativeTargetPath = targetPath.relativeTo(repositoryPath)
+    private val pattern = relativeTargetPath.pathString.replace("\\", "/")
 
     /**
      * Adds the target path to the Git index using the bundled JGit library.
@@ -44,7 +45,7 @@ class AddOperation(
      */
     override fun operateWithBundled(): Either<GitError, Unit> = catchOrThrow<GitAPIException, Unit> {
         val localRepository = Git.open(repositoryPath.toFile())
-        val pattern = relativeTargetPath.pathString.replace("\\", "/")
+
         localRepository.add()
             .addFilepattern(pattern)
             .call()
@@ -58,7 +59,7 @@ class AddOperation(
      * @return An [Either] containing a [GitError] on failure or the process's exit code on success.
      */
     override fun operateWithSystem(): Either<GitError, Int> = either {
-        val args = listOf("add", relativeTargetPath.pathString)
+        val args = listOf("add", pattern)
 
         executeSystemGit(args, repositoryPath).bind()
     }

--- a/src/test/kotlin/git/AddOperationTest.kt
+++ b/src/test/kotlin/git/AddOperationTest.kt
@@ -6,42 +6,33 @@ import com.an5on.git.AddOperation
 import com.an5on.type.BooleanWithAuto
 import org.eclipse.jgit.api.Git
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
-import kotlin.io.path.Path
 import kotlin.io.path.relativeTo
+import kotlin.io.path.writeText
 
 class AddOperationTest : BaseTestWithTestConfiguration() {
-
-    companion object {
-        @JvmStatic
-        @BeforeAll
-        fun setupLogDir() {
-            System.setProperty("log.dir", Files.createTempDirectory("test-logs").toString())
-        }
-    }
-
     @Test
     fun operateWithBundledWithLocalDirectory() {
 
         val git = Git.init().setDirectory(configuration.global.localStatePath.toFile()).call()
 
-        val fileDir = Files.createTempDirectory(configuration.global.localStatePath, ".dir")
-        val file = fileDir.resolve("file.txt").toFile().apply { writeText("hello") }
-        val filePath = Path(file.toString().replace("\\", "/"))
+        val fileDir = configuration.global.localStatePath.resolve("dir")
+        Files.createDirectories(fileDir)
+        val file = fileDir.resolve("file.txt")
+        file.writeText("hello")
 
         val op = AddOperation(
             BooleanWithAuto.TRUE,
             repositoryPath = configuration.global.localStatePath,
-            targetPath = filePath
+            targetPath = file
         )
 
         val result = op.operateWithBundled()
         assertTrue(result.isRight())
 
         val status = git.status().call()
-        val expectedPath = filePath.relativeTo(configuration.global.localStatePath).toString().replace("\\", "/")
+        val expectedPath = file.relativeTo(configuration.global.localStatePath).toString().replace("\\", "/")
         println("added: ${status.added}")
         println("changed: ${status.changed}")
         println("untracked: ${status.untracked}")
@@ -56,10 +47,10 @@ class AddOperationTest : BaseTestWithTestConfiguration() {
         val git = Git.init().setDirectory(configuration.global.localStatePath.toFile()).call()
 
         // create file
-//        should fix since the add operation doesn't allow to have pathString starts with "."
-        val fileDir = configuration.global.localStatePath.resolve(".dir")
+        val fileDir = configuration.global.localStatePath.resolve("dir")
         Files.createDirectories(fileDir)
-        val file = fileDir.resolve("file.txt").toFile().apply { writeText("hello") }.toPath()
+        val file = fileDir.resolve("file.txt")
+        file.writeText("hello")
 
         // Instantiate AddOperation with bundled = False
         val op = AddOperation(
@@ -73,7 +64,7 @@ class AddOperationTest : BaseTestWithTestConfiguration() {
 
         // verify staged
         val status = git.status().call()
-        val expectedPath = file.relativeTo(configuration.global.localStatePath).toString()
+        val expectedPath = file.relativeTo(configuration.global.localStatePath).toString().replace("\\", "/")
         println("added: ${status.added}")
         println("changed: ${status.changed}")
         println("untracked: ${status.untracked}")

--- a/src/test/kotlin/git/AddOperationTest.kt
+++ b/src/test/kotlin/git/AddOperationTest.kt
@@ -1,0 +1,88 @@
+package git
+
+import BaseTestWithTestConfiguration
+import com.an5on.config.ActiveConfiguration.configuration
+import com.an5on.git.AddOperation
+import com.an5on.type.BooleanWithAuto
+import org.eclipse.jgit.api.Git
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import kotlin.io.path.relativeTo
+
+class AddOperationTest : BaseTestWithTestConfiguration() {
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun setupLogDir() {
+            System.setProperty("log.dir", Files.createTempDirectory("test-logs").toString())
+        }
+    }
+
+    @Test
+    fun operateWithBundledWithLocalDirectory() {
+
+        // init repo
+        val git = Git.init().setDirectory(configuration.global.localStatePath.toFile()).call()
+
+        // create file
+//        should fix since the add operation doesn't allow to have pathString starts with "."
+        val fileDir = configuration.global.localStatePath.resolve(".dir")
+        Files.createDirectories(fileDir)
+        val file = fileDir.resolve("file.txt").toFile().apply { writeText("hello") }.toPath()
+
+        // Instantiate AddOperation with bundled = TRUE
+        val op = AddOperation(
+            BooleanWithAuto.TRUE,
+            repositoryPath = configuration.global.localStatePath,
+            targetPath = file
+        )
+
+        val result = op.operateWithBundled()
+        assertTrue(result.isRight())
+
+        // verify staged
+        val status = git.status().call()
+        val expectedPath = file.relativeTo(configuration.global.localStatePath).toString()
+        println("added: ${status.added}")
+        println("changed: ${status.changed}")
+        println("untracked: ${status.untracked}")
+        assertTrue(status.added.contains(expectedPath), "expected $expectedPath to be staged, got ${status.added}")
+
+    }
+
+    @Test
+    fun operateWithSystemWithLocalDirectory() {
+
+        // init repo
+        val git = Git.init().setDirectory(configuration.global.localStatePath.toFile()).call()
+
+        // create file
+//        should fix since the add operation doesn't allow to have pathString starts with "."
+        val fileDir = configuration.global.localStatePath.resolve(".dir")
+        Files.createDirectories(fileDir)
+        val file = fileDir.resolve("file.txt").toFile().apply { writeText("hello") }.toPath()
+
+        // Instantiate AddOperation with bundled = False
+        val op = AddOperation(
+            BooleanWithAuto.FALSE,
+            repositoryPath = configuration.global.localStatePath,
+            targetPath = file
+        )
+
+        val result = op.operateWithSystem()
+        assertTrue(result.isRight())
+
+        // verify staged
+        val status = git.status().call()
+        val expectedPath = file.relativeTo(configuration.global.localStatePath).toString()
+        println("added: ${status.added}")
+        println("changed: ${status.changed}")
+        println("untracked: ${status.untracked}")
+        assertTrue(status.added.contains(expectedPath), "expected $expectedPath to be staged, got ${status.added}")
+
+    }
+
+}

--- a/src/test/kotlin/git/CommitOperationTest.kt
+++ b/src/test/kotlin/git/CommitOperationTest.kt
@@ -1,0 +1,151 @@
+package git
+
+import BaseTestWithTestConfiguration
+import com.an5on.config.ActiveConfiguration.configuration
+import com.an5on.error.GitError
+import com.an5on.git.CommitOperation
+import com.an5on.git.CommitOperation.Companion.substituteCommitMessage
+import com.an5on.type.BooleanWithAuto
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.errors.EmptyCommitException
+import org.eclipse.jgit.errors.RepositoryNotFoundException
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeAll
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class CommitOperationTest : BaseTestWithTestConfiguration() {
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun setupLogDir() {
+            System.setProperty("log.dir", Files.createTempDirectory("test-logs").toString())
+        }
+    }
+
+    @Test
+    fun operateWithBundledWithRepo() {
+        // init repo
+        val git = Git.init().setDirectory(configuration.global.localStatePath.toFile()).call()
+
+        // Add a file to be committed
+        val testFile = configuration.global.localStatePath.resolve("test.txt").toFile()
+        testFile.writeText("hello world")
+        git.add().addFilepattern("test.txt").call()
+
+        val op = CommitOperation(
+            useBundledGitOption = BooleanWithAuto.TRUE,
+            repositoryPath = configuration.global.localStatePath,
+            message = "It is a test message",
+        )
+
+        val result = op.operateWithBundled()
+        assertTrue(result.isRight())
+
+        val commitMessages = git.log().call().map { it.fullMessage }
+        assertTrue(commitMessages.any { it.trim() == "It is a test message" })
+    }
+
+    @Test
+    fun operateWithSystemWithRepo() {
+        // init repo
+        val git = Git.init().setDirectory(configuration.global.localStatePath.toFile()).call()
+
+        // Add a file to be committed
+        val testFile = configuration.global.localStatePath.resolve("test.txt").toFile()
+        testFile.writeText("hello world")
+        git.add().addFilepattern("test.txt").call()
+
+        val op = CommitOperation(
+            useBundledGitOption = BooleanWithAuto.FALSE,
+            repositoryPath = configuration.global.localStatePath,
+            message = "It is a test message",
+        )
+
+        val result = op.operateWithSystem()
+        assertTrue(result.isRight())
+
+        val commitMessages = git.log().call().map { it.fullMessage }
+        assertTrue(commitMessages.any { it.trim() == "It is a test message" })
+    }
+
+
+    @Test
+    fun operationWithBundledWithUnchangedRepository() {
+        // init repo and make one commit
+        val git = Git.init().setDirectory(configuration.global.localStatePath.toFile()).call()
+        val testFile = configuration.global.localStatePath.resolve("test.txt").toFile()
+        testFile.writeText("initial content")
+        git.add().addFilepattern("test.txt").call()
+        git.commit().setMessage("Initial commit").call()
+
+        // try to commit again with no changes
+        val op = CommitOperation(
+            useBundledGitOption = BooleanWithAuto.TRUE,
+            repositoryPath = configuration.global.localStatePath,
+            message = "This should fail",
+        )
+
+        val result = op.operateWithBundled()
+        result.onLeft {
+            assertIs<GitError.BundledGitOperationFailed>(it)
+            assertIs<EmptyCommitException>(it.cause)
+        }
+    }
+
+    @Test
+    fun operateWithBundledWithFileDirectory() {
+        // Don't init a repo, just use a plain directory
+        val invalidRepoPath = Files.createTempDirectory("not-a-repo")
+        val op = CommitOperation(
+            useBundledGitOption = BooleanWithAuto.TRUE,
+            repositoryPath = invalidRepoPath,
+            message = "This should fail",
+        )
+
+        val expectation = assertThrows(RepositoryNotFoundException::class.java) {
+            op.operateWithBundled()
+        }
+
+        println(expectation.message)
+        assertTrue(expectation.message!!.contains("repository not found"))
+    }
+
+    @Test
+    fun operationWithBundledWithNullMessage() {
+
+        Git.init().setDirectory(configuration.global.localStatePath.toFile()).call()
+
+        val op = CommitOperation(
+            useBundledGitOption = BooleanWithAuto.TRUE,
+            repositoryPath = configuration.global.localStatePath,
+            message = "",
+        )
+
+        val result = op.operateWithBundled()
+        assertTrue(result.isRight())
+
+    }
+
+    @Test
+    fun substituteCommitMessageWithValidMessage() {
+        val userName = System.getProperty("user.name")
+        val message = "User \${sys:user.name} performed \${op}"
+        val operationName = "unsync"
+        val result = substituteCommitMessage(message, operationName)
+        assertEquals("User $userName performed unsync", result)
+    }
+
+    @Test
+    fun substituteCommitMessageWithEmptyMessage() {
+        val message = ""
+        val operationName = "sync"
+        val result = substituteCommitMessage(message, operationName)
+        assertEquals("", result)
+
+    }
+}

--- a/src/test/kotlin/git/CommitOperationTest.kt
+++ b/src/test/kotlin/git/CommitOperationTest.kt
@@ -10,7 +10,6 @@ import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.errors.EmptyCommitException
 import org.eclipse.jgit.errors.RepositoryNotFoundException
 import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.BeforeAll
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -18,14 +17,6 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class CommitOperationTest : BaseTestWithTestConfiguration() {
-
-    companion object {
-        @JvmStatic
-        @BeforeAll
-        fun setupLogDir() {
-            System.setProperty("log.dir", Files.createTempDirectory("test-logs").toString())
-        }
-    }
 
     @Test
     fun operateWithBundledWithRepo() {

--- a/src/test/kotlin/git/GenericOperationWithSystemTest.kt
+++ b/src/test/kotlin/git/GenericOperationWithSystemTest.kt
@@ -1,0 +1,42 @@
+package git
+
+import BaseTestWithTestConfiguration
+import com.an5on.config.ActiveConfiguration.configuration
+import com.an5on.git.GenericOperationWithSystem
+import org.eclipse.jgit.api.Git
+import org.junit.jupiter.api.BeforeAll
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class GenericOperationWithSystemTest : BaseTestWithTestConfiguration() {
+
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun setupLogDir() {
+            System.setProperty("log.dir", Files.createTempDirectory("test-logs").toString())
+        }
+    }
+
+    @Test
+    fun operateWithSystemWithRepo() {
+        // init repo
+        val git = Git.init().setDirectory(configuration.global.localStatePath.toFile()).call()
+
+        // Add a file to be committed
+        val testFile = configuration.global.localStatePath.resolve("test.txt").toFile()
+        testFile.writeText("hello world")
+        git.add().addFilepattern("test.txt").call()
+
+        val op = GenericOperationWithSystem(listOf("commit", "-m", "It is a test message"))
+
+        val result = op.operateWithSystem()
+        assertTrue(result.isRight())
+
+        val commitMessages = git.log().call().map { it.fullMessage }
+        assertTrue(commitMessages.any { it.trim() == "It is a test message" })
+    }
+
+}

--- a/src/test/kotlin/git/GenericOperationWithSystemTest.kt
+++ b/src/test/kotlin/git/GenericOperationWithSystemTest.kt
@@ -4,22 +4,10 @@ import BaseTestWithTestConfiguration
 import com.an5on.config.ActiveConfiguration.configuration
 import com.an5on.git.GenericOperationWithSystem
 import org.eclipse.jgit.api.Git
-import org.junit.jupiter.api.BeforeAll
-import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
 class GenericOperationWithSystemTest : BaseTestWithTestConfiguration() {
-
-
-    companion object {
-        @JvmStatic
-        @BeforeAll
-        fun setupLogDir() {
-            System.setProperty("log.dir", Files.createTempDirectory("test-logs").toString())
-        }
-    }
-
     @Test
     fun operateWithSystemWithRepo() {
         // init repo


### PR DESCRIPTION
This pull request improves the reliability and correctness of Git operations by standardizing path handling in the `AddOperation` class and adds comprehensive unit tests for Git-related operations. The changes ensure consistent behavior across different operating systems and provide better test coverage for both bundled and system Git integrations.

**Path handling improvements:**

* Standardized the file pattern used in `AddOperation` to always use forward slashes, ensuring compatibility across platforms and fixing potential issues with staging files in subdirectories. (`src/main/kotlin/git/AddOperation.kt`) [[1]](diffhunk://#diff-f1a62ee233d99a5959a08c6ba16a2f49f491be1134193680ce1e0131ece48e27R39) [[2]](diffhunk://#diff-f1a62ee233d99a5959a08c6ba16a2f49f491be1134193680ce1e0131ece48e27L49-R50) [[3]](diffhunk://#diff-f1a62ee233d99a5959a08c6ba16a2f49f491be1134193680ce1e0131ece48e27L61-R62)

**Test coverage enhancements:**

* Added `AddOperationTest` to verify both bundled and system Git add operations, ensuring files in subdirectories are correctly staged. (`src/test/kotlin/git/AddOperationTest.kt`)
* Added `CommitOperationTest` to cover various commit scenarios, including successful commits, empty commits, invalid repositories, and commit message substitution. (`src/test/kotlin/git/CommitOperationTest.kt`)
* Added `GenericOperationWithSystemTest` to validate generic system Git operations, such as committing via command-line arguments. (`src/test/kotlin/git/GenericOperationWithSystemTest.kt`)